### PR TITLE
Use JIT CDI spec generation by default

### DIFF
--- a/examples/equally-distributed-gpus.yaml
+++ b/examples/equally-distributed-gpus.yaml
@@ -39,6 +39,6 @@ nodes:
     # in `/etc/nvidia-container-runtime/config.toml`
     {{- range $gpu := $gpus }}
     - hostPath: /dev/null
-      containerPath: /var/run/nvidia-container-devices/{{ $gpu }}
+      containerPath: /var/run/nvidia-container-devices/cdi/runtime.nvidia.com/gpu/{{ $gpu }}
     {{- end }}
 {{- end }}

--- a/examples/one-worker-per-gpu.yaml
+++ b/examples/one-worker-per-gpu.yaml
@@ -23,5 +23,5 @@ nodes:
     # This requires `accept-nvidia-visible-devices-as-volume-mounts = true` be set
     # in `/etc/nvidia-container-runtime/config.toml`
     - hostPath: /dev/null
-      containerPath: /var/run/nvidia-container-devices/{{ $gpu }}
+      containerPath: /var/run/nvidia-container-devices/cdi/runtime.nvidia.com/gpu/{{ $gpu }}
 {{- end }}

--- a/pkg/nvkind/default-config-template.yaml
+++ b/pkg/nvkind/default-config-template.yaml
@@ -39,7 +39,7 @@ nodes:
     # in `/etc/nvidia-container-runtime/config.toml`
     {{- range $d := $devices }}
     - hostPath: /dev/null
-      containerPath: /var/run/nvidia-container-devices/{{ $d }}
+      containerPath: /var/run/nvidia-container-devices/cdi/runtime.nvidia.com/gpu/{{ $d }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/pkg/nvkind/node.go
+++ b/pkg/nvkind/node.go
@@ -177,10 +177,15 @@ func (n *Node) getNvidiaVisibleDevices() []string {
 		if mount.HostPath != "/dev/null" {
 			continue
 		}
-		if filepath.Dir(mount.ContainerPath) != "/var/run/nvidia-container-devices" {
-			continue
+		dir := filepath.Dir(mount.ContainerPath)
+		deviceID := filepath.Base(mount.ContainerPath)
+		switch {
+		case strings.HasPrefix(dir, "/var/run/nvidia-container-devices/cdi"):
+			cdiKind := strings.TrimPrefix(dir, "/var/run/nvidia-container-devices/cdi/")
+			devices = append(devices, cdiKind+"="+deviceID)
+		case dir == "/var/run/nvidia-container-devices":
+			devices = append(devices, deviceID)
 		}
-		devices = append(devices, filepath.Base(mount.ContainerPath))
 	}
 
 	return devices


### PR DESCRIPTION
This change switches to using JIT CDI spec generation in the NVIDIA Contianer Runtime instead of the legacy injection mechanism.