### PR TITLE
.github: enable copy-pr-bot

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,6 @@
+enabled: true
+additional_trustees:
+  - ArangoGutierrez
+  - cdesiniotis
+  - dims
+  - tariq1890


### PR DESCRIPTION
Enables NVIDIA's [`copy-pr-bot`](https://github.com/nvidia/nv-gha-runners-docs/blob/main/docs/platform/apps/copy-pr-bot/index.md) for this repo.

The bot mirrors external-fork PR branches into upstream under `pull-request/<N>`, which lets workflows triggered by the resulting `push` event run on NVIDIA self-hosted runners (self-hosted runners refuse `pull_request` events from forks by policy).

Minimal config (matches the `NVIDIA/aicr` setup):
- `enabled: true`
- `additional_trustees: [dims]`

Landing this ahead of the GPU e2e workflow in #67 so fork PRs get auto-mirrored by the time that workflow arrives.