### PR TITLE
Replace deprecated runtime option with gpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Likewise, running the following on a host with a functioning
 the same output as above:
 
 ```bash
-$ docker run --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all ubuntu:20.04 nvidia-smi -L
+$ docker run --gpus=all ubuntu nvidia-smi -L
 GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-4cf8db2d-06c0-7d70-1a51-e59b25b2c16c)
 GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-4404041a-04cf-1ccf-9e70-f139a9b1e23c)
 GPU 2: NVIDIA A100-SXM4-40GB (UUID: GPU-79a2ba02-a537-ccbf-2965-8e9d90c0bd54)


### PR DESCRIPTION
Hi,

The runtime option does not work:

```console
docker run --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all ubuntu nvidia-smi -L
```

Replacing it with gpus works fine:

```console
docker run --gpus=all alpine nvidia-smi -L
```

Cheers,