### PR TITLE
Update nvidia-ctk --config-source flag from 'command' to 'file'

### DIFF
--- a/pkg/nvkind/node.go
+++ b/pkg/nvkind/node.go
@@ -50,7 +50,7 @@ func (n *Node) InstallContainerToolkit() error {
 
 func (n *Node) ConfigureContainerRuntime() error {
 	err := n.runScript(`
-	    nvidia-ctk runtime configure --runtime=containerd --config-source=command
+	    nvidia-ctk runtime configure --runtime=containerd --config-source=file
 	    systemctl restart containerd
 	`)
 	if err != nil {


### PR DESCRIPTION
Using command as a config source can be problematic with containerd. The 'containerd config dump' command does not reliably inform us of the config file version currently set in the top-level /etc/containerd/config.toml file. For newer versions of containerd that support config versions 3 (or even 4), we fail to generate a valid drop-in config file if the top-level config is using version 2 of the containerd config schema.

In kind worker nodes (e.g. kindest/node:$k8s-ver), the top-level /etc/containerd/config.toml is populated with enough information for nvidia-ctk to create a functional drop-in file at /etc/containerd/conf.d/99-nvidia.toml. So it should be safe, at least in kind environments, to use 'file' as our config source.